### PR TITLE
Added fast_sync.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 *__pycache__/
 *~
 dist/
+build/
 
 # Singer JSON files
 properties.json
@@ -32,3 +33,4 @@ docs/_templates/
 
 # Environment
 .env
+

--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -164,7 +164,7 @@ def _persist_line(
             "A record for stream {} was encountered before a corresponding schema".format(o['stream']))
 
     # Get schema for this record's stream
-    stream = o['stream']
+    stream = container['stream']
 
     adjust_timestamps_in_record(record, schemas[stream])
 
@@ -194,7 +194,7 @@ def _persist_line(
 
     # append record
     if config.get('add_metadata_columns') or config.get('hard_delete'):
-        records_to_load[stream][primary_key_string] = add_metadata_values_to_record(o, stream_to_sync[stream])
+        records_to_load[stream][primary_key_string] = add_metadata_values_to_record(container, stream_to_sync[stream])
     else:
         records_to_load[stream][primary_key_string] = record
 
@@ -255,10 +255,11 @@ def persist_lines(config, lines, table_cache=None) -> None:
                 LOGGER.debug("Batch message detected. Running in fast_sync mode.")
                 batch_file = o['record'].get('file_path')
                 if os.path.exists(batch_file):
+                    LOGGER.info(f"Reading batch file '{batch_file}'")
                     with open(batch_file, 'r') as f:
                         for i, fline in enumerate(f):
-                            container = load_line(fline)
-                            record = container['record']
+                            container = o
+                            record = load_line(fline)
                             _persist_line(
                                 container, record, config,
                                 state, flushed_state, schemas, validators,

--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -150,6 +150,83 @@ def adjust_timestamps_in_record(record: Dict, schema: Dict) -> None:
                     reset_new_value(record, key, schema['properties'][key]['format'])
 
 
+def _persist_line(
+    container, record, config,
+    state, flushed_state, schemas, validators,
+    records_to_load, row_count, stream_to_sync,
+    total_row_count, batch_size_rows
+):
+
+    if 'stream' not in container:
+        raise Exception("Line is missing required key 'stream': {}".format(line))
+    if container['stream'] not in schemas:
+        raise Exception(
+            "A record for stream {} was encountered before a corresponding schema".format(o['stream']))
+
+    # Get schema for this record's stream
+    stream = o['stream']
+
+    adjust_timestamps_in_record(record, schemas[stream])
+
+    # Validate record
+    if config.get('validate_records'):
+        try:
+            validators[stream].validate(float_to_decimal(record))
+        except Exception as ex:
+            if type(ex).__name__ == "InvalidOperation":
+                raise InvalidValidationOperationException(
+                    f"Data validation failed and cannot load to destination. RECORD: {record}\n"
+                    "multipleOf validations that allows long precisions are not supported (i.e. with 15 digits"
+                    "or more) Try removing 'multipleOf' methods from JSON schema.")
+            raise RecordValidationException(f"Record does not pass schema validation. RECORD: {record}")
+
+    primary_key_string = stream_to_sync[stream].record_primary_key_string(record)
+    if not primary_key_string:
+        primary_key_string = 'RID-{}'.format(total_row_count[stream])
+
+    if stream not in records_to_load:
+        records_to_load[stream] = {}
+
+    # increment row count only when a new PK is encountered in the current batch
+    if primary_key_string not in records_to_load[stream]:
+        row_count[stream] += 1
+        total_row_count[stream] += 1
+
+    # append record
+    if config.get('add_metadata_columns') or config.get('hard_delete'):
+        records_to_load[stream][primary_key_string] = add_metadata_values_to_record(o, stream_to_sync[stream])
+    else:
+        records_to_load[stream][primary_key_string] = record
+
+    if row_count[stream] >= batch_size_rows:
+        # flush all streams, delete records if needed, reset counts and then emit current state
+        if config.get('flush_all_streams'):
+            filter_streams = None
+        else:
+            filter_streams = [stream]
+
+        # Flush and return a new state dict with new positions only for the flushed streams
+        flushed_state = flush_streams(
+            records_to_load,
+            row_count,
+            stream_to_sync,
+            config,
+            state,
+            flushed_state,
+            filter_streams=filter_streams)
+
+        # emit last encountered state
+        emit_state(copy.deepcopy(flushed_state))
+
+
+def load_line(line):
+    try:
+        return json.loads(line)
+    except json.decoder.JSONDecodeError:
+        LOGGER.error("Unable to parse:\n{}".format(line))
+        raise
+
+
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def persist_lines(config, lines, table_cache=None) -> None:
     state = None
@@ -165,11 +242,7 @@ def persist_lines(config, lines, table_cache=None) -> None:
 
     # Loop over lines from stdin
     for line in lines:
-        try:
-            o = json.loads(line)
-        except json.decoder.JSONDecodeError:
-            LOGGER.error("Unable to parse:\n{}".format(line))
-            raise
+        o = load_line(line)
 
         if 'type' not in o:
             raise Exception("Line is missing required key 'type': {}".format(line))
@@ -177,66 +250,28 @@ def persist_lines(config, lines, table_cache=None) -> None:
         t = o['type']
 
         if t == 'RECORD':
-            if 'stream' not in o:
-                raise Exception("Line is missing required key 'stream': {}".format(line))
-            if o['stream'] not in schemas:
-                raise Exception(
-                    "A record for stream {} was encountered before a corresponding schema".format(o['stream']))
 
-            # Get schema for this record's stream
-            stream = o['stream']
-
-            adjust_timestamps_in_record(o['record'], schemas[stream])
-
-            # Validate record
-            if config.get('validate_records'):
-                try:
-                    validators[stream].validate(float_to_decimal(o['record']))
-                except Exception as ex:
-                    if type(ex).__name__ == "InvalidOperation":
-                        raise InvalidValidationOperationException(
-                            f"Data validation failed and cannot load to destination. RECORD: {o['record']}\n"
-                            "multipleOf validations that allows long precisions are not supported (i.e. with 15 digits"
-                            "or more) Try removing 'multipleOf' methods from JSON schema.")
-                    raise RecordValidationException(f"Record does not pass schema validation. RECORD: {o['record']}")
-
-            primary_key_string = stream_to_sync[stream].record_primary_key_string(o['record'])
-            if not primary_key_string:
-                primary_key_string = 'RID-{}'.format(total_row_count[stream])
-
-            if stream not in records_to_load:
-                records_to_load[stream] = {}
-
-            # increment row count only when a new PK is encountered in the current batch
-            if primary_key_string not in records_to_load[stream]:
-                row_count[stream] += 1
-                total_row_count[stream] += 1
-
-            # append record
-            if config.get('add_metadata_columns') or config.get('hard_delete'):
-                records_to_load[stream][primary_key_string] = add_metadata_values_to_record(o, stream_to_sync[stream])
+            if config.get('fast_sync') and o['record'].get('__fast_sync_message__', False):
+                LOGGER.debug("Batch message detected. Running in fast_sync mode.")
+                batch_file = o['record'].get('file_path')
+                if os.path.exists(batch_file):
+                    with open(batch_file, 'r') as f:
+                        for i, fline in enumerate(f):
+                            container = load_line(fline)
+                            record = container['record']
+                            _persist_line(
+                                container, record, config,
+                                state, flushed_state, schemas, validators,
+                                records_to_load, row_count, stream_to_sync,
+                                total_row_count, batch_size_rows
+                            )
             else:
-                records_to_load[stream][primary_key_string] = o['record']
-
-            if row_count[stream] >= batch_size_rows:
-                # flush all streams, delete records if needed, reset counts and then emit current state
-                if config.get('flush_all_streams'):
-                    filter_streams = None
-                else:
-                    filter_streams = [stream]
-
-                # Flush and return a new state dict with new positions only for the flushed streams
-                flushed_state = flush_streams(
-                    records_to_load,
-                    row_count,
-                    stream_to_sync,
-                    config,
-                    state,
-                    flushed_state,
-                    filter_streams=filter_streams)
-
-                # emit last encountered state
-                emit_state(copy.deepcopy(flushed_state))
+                _persist_line(
+                    o, o['record'], config,
+                    state, flushed_state, schemas, validators,
+                    records_to_load, row_count, stream_to_sync,
+                    total_row_count, batch_size_rows
+                )
 
         elif t == 'SCHEMA':
             if 'stream' not in o:


### PR DESCRIPTION
## Problem

'Fast Sync' is a feature of pipelinewise, _not_ singer. This means folks using this tap outside of pipelinewise do not benefit (*cough*Meltano). This PR enables fast-sync, configurable by setting `"fast_sync": true` in your config.json file.

**WARNING**: fast sync must be supported and enabled by both tap and target for it to work. This target will check for fast_sync-compatible messages on the stream and fall back to standard singer if not recognised. 

## Proposed changes

Piping records between tap and target using STDOUT is slow for tables with large numbers of rows. Therefore I have implemented record batching, with a collection of records serialized to disk and a pointer written into a new BatchRecord. As I have no direct control over the Singer spec, this batch record appears as a standard RECORD, using config and a reserved key (`__fast_sync_message__`) to identify these new messages.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions